### PR TITLE
#33191 Fix for the action menus showing up offscreen.

### DIFF
--- a/python/app/dialog.py
+++ b/python/app/dialog.py
@@ -124,10 +124,17 @@ class AppDialog(QtGui.QWidget):
         self.ui.entity_activity_stream.set_data_retriever(self._sg_data_retriever)
         self.ui.version_activity_stream.set_data_retriever(self._sg_data_retriever)
 
-        # set up action menu
-        self._menu = QtGui.QMenu()
+        # set up action menu. parent it to the action button to prevent cases
+        # where it shows up elsewhere on screen (as in Houdini)
+        self._menu = QtGui.QMenu(self.ui.action_button)
         self._actions = []
         self.ui.action_button.setMenu(self._menu)        
+
+        # this forces the menu to be right aligned with the button. This is
+        # preferable since many DCCs show the embed panel on the far right. In
+        # houdini at least, before forcing this layout direction, the menu was
+        # showing up partially offscreen.
+        self.ui.action_button.setLayoutDirection(QtCore.Qt.RightToLeft)
         
         # our current object we are currently displaying
         self._current_location = None

--- a/python/app/widget_list_item.py
+++ b/python/app/widget_list_item.py
@@ -72,12 +72,18 @@ class ListItemWidget(QtGui.QWidget):
             }        
             """
 
-        # set up action menu
-        self._menu = QtGui.QMenu()
+        # set up action menu. parent it to the button to prevent cases where it
+        # shows up elsewhere on screen (as in Houdini)
+        self._menu = QtGui.QMenu(self.ui.button)
         self._actions = []
         self.ui.button.setMenu(self._menu)
         self.ui.button.setVisible(False)
                                   
+        # this forces the menu to be right aligned with the button. This is
+        # preferable since many DCCs show the embed panel on the far right.  In
+        # houdini at least, before forcing this layout direction, the menu was
+        # showing up partially offscreen.
+        self.ui.button.setLayoutDirection(QtCore.Qt.RightToLeft)
 
     def set_selected(self, selected):
         """


### PR DESCRIPTION
Addresses issues in Houdini where action menu was showing up offscreen. It
looks other DCCs handle moving the menu appropriately when close to screen
boundaries. Houdini did not, so now enforcing a right-to-left alignment with
the action button.