### PR TITLE
#31428 API support for panel navigation

### DIFF
--- a/app.py
+++ b/app.py
@@ -62,8 +62,8 @@ class ShotgunPanelApp(Application):
           the panel if it doesn't already exist. If it exists it will be given user focus. Note that
           on engines without panel support implemented, this flag will be equivalent to DIALOG
           below.
-        - DIALOG - launch the panel as a dialog. A dialog may co-exist with a panel. if a dialog
-          already exists, this is given focus.
+        - DIALOG - launch the panel as a dialog. A dialog may co-exist with a panel. If a dialog
+          already exists, it is given focus.
         - NEW_DIALOG - launch the panel as a dialog without attempting to reuse any 
           existing dialogs that may have been created in previous calls.
         
@@ -114,8 +114,7 @@ class ShotgunPanelApp(Application):
             self.log_warning("Could not execute show_panel method - please upgrade "
                              "to latest core and engine! Falling back on show_dialog. "
                              "Error: %s" % e)
-            widget = self.engine.show_dialog("Shotgun", self, app_payload.AppDialog)
-            self._current_dialog = widget
+            widget = self.create_dialog()
             
         return widget
 
@@ -124,9 +123,9 @@ class ShotgunPanelApp(Application):
         Shows the panel as a dialog.
         
         Contrary to the create_panel() method, multiple calls
-        to this method will result in multiple browser windows appearing. 
+        to this method will result in multiple windows appearing. 
         
-        :returns: The widget associated with the panel. 
+        :returns: The widget associated with the dialog. 
         """
         app_payload = self.import_module("app")
         widget = self.engine.show_dialog("Shotgun", self, app_payload.AppDialog)

--- a/app.py
+++ b/app.py
@@ -17,6 +17,9 @@ class ShotgunPanelApp(Application):
     menu command and panel callbacks.
     """
     
+    # window launch mode constants used by the navigate() method
+    (PANEL, DIALOG, NEW_DIALOG) = range(3)
+    
     def init_app(self):
         """
         Called as the application is being initialized
@@ -32,6 +35,10 @@ class ShotgunPanelApp(Application):
         # example when a saved window layout is restored in Nuke or at startup.
         self._unique_panel_id = self.engine.register_panel(self.create_panel)
         
+        # keep track of the last dialog we have created
+        # in order to support the DIALOG mode for the navigate() method
+        self._current_dialog = None
+        
         # also register a menu entry on the shotgun menu so that users
         # can launch the panel
         self.engine.register_command("Shotgun Panel...", 
@@ -39,6 +46,50 @@ class ShotgunPanelApp(Application):
                                      {"type": "panel", 
                                       "short_name": "shotgun_panel"})
         
+    def navigate(self, entity_type, entity_id, mode):
+        """
+        API support to start the panel and navigate to a location.
+        
+        Depending on the mode parameter, the window behavior may 
+        differ, but the general idea is that if a panel window doesn't exist
+        or isn't in focus, it is created and/or brought to front before navigating
+        to the given entity. The new location is added to the existing history stack,
+        allowing the user to easily move back again if needed and effectively undo 
+        the programmatic navigation.
+        
+        The following modes exist:
+        - PANEL - launch the panel as a panel. Panels are always singleton, so this will start
+          the panel if it doesn't already exist. If it exists it will be given user focus. Note that
+          on engines without panel support implemented, this flag will be equivalent to DIALOG
+          below.
+        - DIALOG - launch the panel as a dialog. A dialog may co-exist with a panel. if a dialog
+          already exists, this is given focus.
+        - NEW_DIALOG - launch the panel as a dialog without attempting to reuse any 
+          existing dialogs that may have been created in previous calls.
+        
+        :param entity_type: Shotgun entity type to navigate to
+        :param entity_id: Shotgun entity id 
+        :param mode: PANEL, DIALOG or NEW_DIALOG
+        """
+        if mode == self.NEW_DIALOG:
+            # always open a new window
+            self.create_dialog()
+            self._current_dialog.navigate_to_entity(entity_type, entity_id)
+        
+        elif mode == self.DIALOG:
+            # show panel as dialog and reuse existing window
+            if not self._current_dialog:
+                self.create_dialog()
+            self._current_dialog.navigate_to_entity(entity_type, entity_id)
+            # bring window to front
+            self._current_dialog.window().raise_()
+            self._current_dialog.window().activateWindow()
+        
+        elif mode == self.PANEL:
+            # show panel and navigate
+            w = self.create_panel()
+            w.navigate_to_entity(entity_type, entity_id)                
+    
     def destroy_app(self):
         """
         Called as part engine shutdown
@@ -47,16 +98,45 @@ class ShotgunPanelApp(Application):
 
     def create_panel(self):
         """
-        Shows the panel UI
+        Shows the UI as a panel. 
+        Note that since panels are singletons by nature,
+        calling this more than once will only result in one panel.
+        
+        :returns: The widget associated with the panel.
         """
         app_payload = self.import_module("app")
         
         # start the UI
         try:
-            return self.engine.show_panel(self._unique_panel_id, "Shotgun", self, app_payload.AppDialog)
+            widget = self.engine.show_panel(self._unique_panel_id, "Shotgun", self, app_payload.AppDialog)
         except AttributeError, e:
             # just to gracefully handle older engines and older cores
             self.log_warning("Could not execute show_panel method - please upgrade "
                              "to latest core and engine! Falling back on show_dialog. "
                              "Error: %s" % e)
-            return self.engine.show_dialog("Shotgun", self, app_payload.AppDialog)
+            widget = self.engine.show_dialog("Shotgun", self, app_payload.AppDialog)
+            self._current_dialog = widget
+            
+        return widget
+
+    def create_dialog(self):
+        """
+        Shows the panel as a dialog.
+        
+        Contrary to the create_panel() method, multiple calls
+        to this method will result in multiple browser windows appearing. 
+        
+        :returns: The widget associated with the panel. 
+        """
+        app_payload = self.import_module("app")
+        widget = self.engine.show_dialog("Shotgun", self, app_payload.AppDialog)
+        self._current_dialog = widget
+        return widget
+
+    def _on_dialog_close(self, dialog):
+        """
+        Callback called by the panel dialog whenever
+        it is about to close.
+        """
+        if dialog == self._current_dialog:
+            self._current_dialog = None

--- a/python/app/dialog.py
+++ b/python/app/dialog.py
@@ -190,9 +190,9 @@ class AppDialog(QtGui.QWidget):
         self.ui.details_text_middle.linkActivated.connect(self._on_link_clicked)
         self.ui.details_thumb.playback_clicked.connect(self._playback_version)
         
-        self.ui.note_reply_widget.entity_requested.connect(self._navigate_to_entity)
-        self.ui.entity_activity_stream.entity_requested.connect(self._navigate_to_entity)
-        self.ui.version_activity_stream.entity_requested.connect(self._navigate_to_entity)
+        self.ui.note_reply_widget.entity_requested.connect(self.navigate_to_entity)
+        self.ui.entity_activity_stream.entity_requested.connect(self.navigate_to_entity)
+        self.ui.version_activity_stream.entity_requested.connect(self.navigate_to_entity)
 
         self.ui.entity_activity_stream.playback_requested.connect(self._playback_version)
         self.ui.version_activity_stream.playback_requested.connect(self._playback_version)
@@ -325,6 +325,9 @@ class AppDialog(QtGui.QWidget):
         """        
         
         self._app.log_debug("CloseEvent Received. Begin shutting down UI.")
+
+        # tell main app instance that we are closing
+        self._app._on_dialog_close(self)
 
         # register a shutdown overlay
         splash_pix = QtGui.QPixmap(":/tk_multi_infopanel/bye_for_now.png")
@@ -652,7 +655,7 @@ class AppDialog(QtGui.QWidget):
         sg_location = ShotgunLocation(sg_item["type"], sg_item["id"])
         self._navigate_to(sg_location)
 
-    def _navigate_to_entity(self, entity_type, entity_id):
+    def navigate_to_entity(self, entity_type, entity_id):
         """
         Navigate to a particular entity.
         A history entry will be created and inserted into the
@@ -697,7 +700,7 @@ class AppDialog(QtGui.QWidget):
             # this is an internal url on the form sgtk:EntityType:entity_id
             (_, entity_type, entity_id) = url.split(":")
             entity_id = int(entity_id)
-            self._navigate_to_entity(entity_type, entity_id)            
+            self.navigate_to_entity(entity_type, entity_id)            
             
         else:
             # all other links are dispatched to the OS


### PR DESCRIPTION
Adds the following methods to the Shotgun Panel:

```
    def navigate(self, entity_type, entity_id, mode):
        """
        API support to start the panel and navigate to a location.
        
        Depending on the mode parameter, the window behavior may 
        differ, but the general idea is that if a panel window doesn't exist
        or isn't in focus, it is created and/or brought to front before navigating
        to the given entity. The new location is added to the existing history stack,
        allowing the user to easily move back again if needed and effectively undo 
        the programmatic navigation.
        
        The following modes exist:
        - PANEL - launch the panel as a panel. Panels are always singleton, so this will start
          the panel if it doesn't already exist. If it exists it will be given user focus. Note that
          on engines without panel support implemented, this flag will be equivalent to DIALOG
          below.
        - DIALOG - launch the panel as a dialog. A dialog may co-exist with a panel. if a dialog
          already exists, this is given focus.
        - NEW_DIALOG - launch the panel as a dialog without attempting to reuse any 
          existing dialogs that may have been created in previous calls.
        
        :param entity_type: Shotgun entity type to navigate to
        :param entity_id: Shotgun entity id 
        :param mode: PANEL, DIALOG or NEW_DIALOG
        """

    def create_panel(self):
        """
        Shows the UI as a panel. 
        Note that since panels are singletons by nature,
        calling this more than once will only result in one panel.
        
        :returns: The widget associated with the panel.
        """

    def create_dialog(self):
        """
        Shows the panel as a dialog.
        
        Contrary to the create_panel() method, multiple calls
        to this method will result in multiple browser windows appearing. 
        
        :returns: The widget associated with the panel. 
        """
```

This can be used to control the panel from another app or script. Simple example that can for example be run inside maya or nuke:

```
import sgtk

app = sgtk.platform.current_engine().apps['tk-multi-shotgunpanel']
app.navigate("Shot", 1692, app.PANEL)
```
