### PR TITLE
[minor] tweaked error reporting when user is unkown

### DIFF
--- a/python/app/dialog.py
+++ b/python/app/dialog.py
@@ -124,7 +124,13 @@ class AppDialog(QtGui.QWidget):
         # where it shows up elsewhere on screen (as in Houdini)
         self._menu = QtGui.QMenu(self.ui.action_button)
         self._actions = []
-        self.ui.action_button.setMenu(self._menu)        
+        self.ui.action_button.setMenu(self._menu)
+
+        # If Toolkit can't determine the current user, add a tooltip to the current_user
+        # button and disable it since it won't work.
+        if sgtk.util.get_current_user(self._app.sgtk) is None:
+            self.ui.current_user.setEnabled(False)
+            self.ui.current_user.setToolTip("The current user is unknown.")
 
         # this forces the menu to be right aligned with the button. This is
         # preferable since many DCCs show the embed panel on the far right. In

--- a/python/app/dialog.py
+++ b/python/app/dialog.py
@@ -126,12 +126,6 @@ class AppDialog(QtGui.QWidget):
         self._actions = []
         self.ui.action_button.setMenu(self._menu)
 
-        # If Toolkit can't determine the current user, add a tooltip to the current_user
-        # button and disable it since it won't work.
-        if sgtk.util.get_current_user(self._app.sgtk) is None:
-            self.ui.current_user.setEnabled(False)
-            self.ui.current_user.setToolTip("The current user is unknown.")
-
         # this forces the menu to be right aligned with the button. This is
         # preferable since many DCCs show the embed panel on the far right. In
         # houdini at least, before forcing this layout direction, the menu was
@@ -605,18 +599,25 @@ class AppDialog(QtGui.QWidget):
     # top detail area callbacks
 
     def _update_current_user(self):        
-        """        
-        Update the current user icon     
         """
-        curr_user_pixmap = self._current_user_model.get_pixmap()        
-                
-        # QToolbutton needs a QIcon      
-        self.ui.current_user.setIcon(QtGui.QIcon(curr_user_pixmap))        
-                
-        # updat the reply icon                
-        sg_data = self._current_user_model.get_sg_data()        
-        if sg_data:        
-            self.ui.current_user.setToolTip("%s's Home" % sg_data["firstname"])
+        Update the current user icon
+        """
+        # Do not test for data availability from the model, since
+        if self._current_user_model.get_sg_link():
+            curr_user_pixmap = self._current_user_model.get_pixmap()        
+
+            # QToolbutton needs a QIcon
+            self.ui.current_user.setIcon(QtGui.QIcon(curr_user_pixmap))
+
+            # updat the reply icon
+            sg_data = self._current_user_model.get_sg_data()        
+            if sg_data:        
+                self.ui.current_user.setToolTip("%s's Home" % sg_data["firstname"])
+        else:
+            # If Toolkit can't determine the current user, add a tooltip to the current_user
+            # button and disable it since it won't work.
+            self.ui.current_user.setEnabled(False)
+            self.ui.current_user.setToolTip("The current user is unknown.")
 
     def _refresh_details_thumbnail(self):
         """

--- a/python/app/model_current_user.py
+++ b/python/app/model_current_user.py
@@ -88,11 +88,14 @@ class SgCurrentUserModel(ShotgunModel):
         """
         app = sgtk.platform.current_bundle()
         sg_user_data = sgtk.util.get_current_user(app.sgtk)
-        
+
         if sg_user_data is None:
-            self._app.log_warning("No current user found! Will continue "
-                                  "without a current user.")
-        
+            self._app.log_warning(
+                "Shotgun Panel can't determine the identity of the current user. "
+                "It won't be able to display the current user's information."
+            )
+            self._app.log_debug("Authenticated user: %r" % sgtk.get_authenticated_user())
+
         else:
             self._current_user_sg_dict = {"type": sg_user_data["type"], 
                                           "id": sg_user_data["id"]}


### PR DESCRIPTION
When Toolkit can't determine what the current user is
- the user button is now disabled and a tooltip is added to it
- the message warning message in the log is more descriptive.
