### PR TITLE
Close the current panel on app destroy

### DIFF
--- a/app.py
+++ b/app.py
@@ -127,6 +127,11 @@ class ShotgunPanelApp(Application):
         """
         self.log_debug("Destroying app...")
 
+        # Closing the current panel
+        if self._current_panel is not None:
+            self._current_panel.close()
+
+
     def create_panel(self):
         """
         Shows the UI as a panel. 


### PR DESCRIPTION
This avoid having a broken state when changing project in flame having the shotgun panel open.

This is linked to [SMOK-42358](https://jira.autodesk.com/browse/SMOK-42358l).

Since it's a panel that is not only for flame, I don't know if this could break the workflow on others integrations. I don't think it will because the app seems to be destroyed only when the engine is getting destroyed.