### PR TITLE
#40162 Upgraded to use open sans

### DIFF
--- a/style.qss
+++ b/style.qss
@@ -10,6 +10,11 @@ agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 not expressly granted therein are reserved by Shotgun Software Inc.
 */
 
+/* Use open sans font across the app if core supports it */
+QWidget {
+    font-family: "Open Sans";
+    font-style: "Regular";
+}
 
 /* Get rid of borders for main Listing Views */
 QListView, QTableView, QScrollArea {


### PR DESCRIPTION
Now uses open sans.

Before:

![image](https://cloud.githubusercontent.com/assets/337710/21753662/cf885190-d5e9-11e6-939f-050b82e64c4d.png)

Now:

![image](https://cloud.githubusercontent.com/assets/337710/21753629/fda08bac-d5e8-11e6-89c9-0a47850ff9f8.png)
