### PR TITLE
#43996 Clicking play in sg panel navigates to sg media player

### DIFF
--- a/python/app/shotgun_formatter.py
+++ b/python/app/shotgun_formatter.py
@@ -444,7 +444,9 @@ class ShotgunTypeFormatter(object):
         if sg_data.get("sg_uploaded_movie"):
             # there is a web quicktime available!
             sg_url = sgtk.platform.current_bundle().sgtk.shotgun_url
-            url = "%s/page/screening_room?entity_type=%s&entity_id=%d" % (sg_url, sg_data["type"], sg_data["id"])                    
+            # redirect to std shotgun player, same as you go to if you click the
+            # play icon inside of the shotgun web ui
+            url = "%s/page/media_center?type=Version&id=%d" % (sg_url, sg_data["id"])
 
         return url
 


### PR DESCRIPTION
This changes the behaviour of the sg panel so that if you click the "play" icon for a version, it will navigate you to the sg media center page rather than screening room which was previously the case. Back when we originally wrote this code, the media center was not yet released and they did not have proper urls that you can navigate to. This change aligns the behaviour in the panel with what you get in the the sg web app.