### PR TITLE
Splat 103 complete amplitude metrics work in toolkit

### DIFF
--- a/app.py
+++ b/app.py
@@ -146,6 +146,26 @@ class ShotgunPanelApp(Application):
             w = self.create_panel()
             w.navigate_to_entity(entity_type, entity_id)
     
+
+    def _log_metric_launched_action(self, action_title):
+        """
+        Module local metric logging helper method for the "Launched Action" metric
+        :param action_title: str of an action which can be most anything
+        """
+        try:
+            from sgtk.util.metrics import EventMetric as EventMetric
+
+            group = EventMetric.GROUP_TOOLKIT
+            properties = self.engine._get_metrics_properties()
+            properties.update({
+                "Action Title": action_title
+            })
+            EventMetric.log(group, "Launched Action", properties = properties)
+
+        except:
+            # ignore all errors. ex: using a core that doesn't support metrics
+            pass
+
     def destroy_app(self):
         """
         Called as part engine shutdown

--- a/app.py
+++ b/app.py
@@ -153,13 +153,11 @@ class ShotgunPanelApp(Application):
         """
         try:
             from sgtk.util.metrics import EventMetric as EventMetric
-
-            group = EventMetric.GROUP_NAVIGATION
-            properties = self.engine._get_metrics_properties()
-            properties.update({"Entity Type": entity_type})
-
             # Log usage statistics about the Shotgun Desktop executable and the desktop startup.
-            EventMetric.log(group, "Viewed Panel", properties=properties)
+            EventMetric.log(EventMetric.GROUP_NAVIGATION,
+                            "Viewed Panel",
+                            properties={"Entity Type": entity_type},
+                            bundle=self)
         except:
             # ignore all errors. ex: using a core that doesn't support metrics
             pass
@@ -171,13 +169,10 @@ class ShotgunPanelApp(Application):
         """
         try:
             from sgtk.util.metrics import EventMetric as EventMetric
-
-            group = EventMetric.GROUP_TOOLKIT
-            properties = self.engine._get_metrics_properties()
-            properties.update({
-                "Action Title": action_title
-            })
-            EventMetric.log(group, "Launched Action", properties = properties)
+            EventMetric.log(EventMetric.GROUP_TOOLKIT,
+                            "Launched Action",
+                            properties = {"Action Title": action_title},
+                            bundle=self)
 
         except:
             # ignore all errors. ex: using a core that doesn't support metrics

--- a/app.py
+++ b/app.py
@@ -152,12 +152,18 @@ class ShotgunPanelApp(Application):
         :param entity_type: str of an entity_type e.g.: HumanUser, Project, Shot etc
         """
         try:
-            from sgtk.util.metrics import EventMetric as EventMetric
-            # Log usage statistics about the Shotgun Desktop executable and the desktop startup.
-            EventMetric.log(EventMetric.GROUP_NAVIGATION,
-                            "Viewed Panel",
-                            properties={"Entity Type": entity_type},
-                            bundle=self)
+            from sgtk.util.metrics import EventMetric
+
+            properties = {
+                "Entity Type": entity_type
+            }
+
+            EventMetric.log(
+                EventMetric.GROUP_NAVIGATION,
+                "Viewed Panel",
+                properties=properties,
+                bundle=self
+            )
         except:
             # ignore all errors. ex: using a core that doesn't support metrics
             pass
@@ -168,11 +174,18 @@ class ShotgunPanelApp(Application):
         :param action_title: str of an action which can be most anything
         """
         try:
-            from sgtk.util.metrics import EventMetric as EventMetric
-            EventMetric.log(EventMetric.GROUP_TOOLKIT,
-                            "Launched Action",
-                            properties = {"Action Title": action_title},
-                            bundle=self)
+            from sgtk.util.metrics import EventMetric
+
+            properties = {
+                "Action Title": action_title
+            }
+            
+            EventMetric.log(
+                EventMetric.GROUP_TOOLKIT,
+                "Launched Action",
+                properties = properties,
+                bundle=self
+            )
 
         except:
             # ignore all errors. ex: using a core that doesn't support metrics

--- a/app.py
+++ b/app.py
@@ -146,6 +146,23 @@ class ShotgunPanelApp(Application):
             w = self.create_panel()
             w.navigate_to_entity(entity_type, entity_id)
     
+    def _log_metric_viewed_panel(self, entity_type):
+        """
+        Module local metric logging helper method for the "Viewed Panel" metric
+        :param entity_type: str of an entity_type e.g.: HumanUser, Project, Shot etc
+        """
+        try:
+            from sgtk.util.metrics import EventMetric as EventMetric
+
+            group = EventMetric.GROUP_NAVIGATION
+            properties = self.engine._get_metrics_properties()
+            properties.update({"Entity Type": entity_type})
+
+            # Log usage statistics about the Shotgun Desktop executable and the desktop startup.
+            EventMetric.log(group, "Viewed Panel", properties=properties)
+        except:
+            # ignore all errors. ex: using a core that doesn't support metrics
+            pass
 
     def _log_metric_launched_action(self, action_title):
         """

--- a/python/app/action_manager.py
+++ b/python/app/action_manager.py
@@ -184,11 +184,7 @@ class ActionManager(QtCore.QObject):
             self._app.log_exception("Could not execute execute_action hook.")
             QtGui.QMessageBox.critical(None, "Action Error", "Error: %s" % e)
         else:
-            try:
-                self._app.log_metric("%s action" % (action_name,))
-            except:
-                # ignore all errors. ex: using a core that doesn't support metrics
-                pass
+            self._app._log_metric_launched_action(action_name)
 
     def _show_docs(self):
         """

--- a/python/app/dialog.py
+++ b/python/app/dialog.py
@@ -804,7 +804,8 @@ class AppDialog(QtGui.QWidget):
         
         # set the current location
         self._current_location = shotgun_location 
-        
+        self._app._log_metric_viewed_panel(shotgun_location.entity_type)
+
         # and set up the UI for this new location
         self._navigating = True
         try:


### PR DESCRIPTION
Similar to desktop, we MIGHT require a specific version of tk-core for the metrics to go through since the last known good tk-core would actually filter out these new events