### PR TITLE
#46459 Removes dependency on Playlist.sg_status

### DIFF
--- a/hooks/general_actions.py
+++ b/hooks/general_actions.py
@@ -106,7 +106,6 @@ class GeneralActions(HookBaseClass):
                 "Playlist",
                 [
                     ["project", "is", sg_data.get("project")],
-                    ["sg_status", "is_not", "clsd"],
                     {
                         "filter_operator": "any",
                         "filters": [


### PR DESCRIPTION
Removes `Playlist.sg_status` filters which is present on some older sites but not on more recent ones.