### PR TITLE
For SG-5387: Adds support for importing Clips into Hiero/Nuke Studio from Publishes.

### DIFF
--- a/hooks/tk-nuke_actions.py
+++ b/hooks/tk-nuke_actions.py
@@ -76,7 +76,7 @@ class NukeActions(HookBaseClass):
         if "clip_import" in actions:
             action_instances.append( {"name": "clip_import",
                                       "params": None,
-                                      "caption": "Create Clip",
+                                      "caption": "Import Clip",
                                       "description": "This will add a Clip to the current project."} )
 
         return action_instances


### PR DESCRIPTION
This mirrors the logic added to tk-multi-loader2, and allows Clips to be created from relevant types of publishes in Nuke Studio and Hiero.