### PR TITLE
For SG-4556: Fixes a crash bug that's possible when script key auth is used.

### DIFF
--- a/hooks/general_actions.py
+++ b/hooks/general_actions.py
@@ -165,7 +165,12 @@ class GeneralActions(HookBaseClass):
         
         if name == "assign_task":
             if app.context.user is None:
-                raise Exception("Cannot establish current user!")
+                raise Exception(
+                    "Shotgun Toolkit does not know what Shotgun user you are. "
+                    "This can be due to the use of a script key for authentication "
+                    "rather than using a user name and password login. To assign a "
+                    "Task, you will need to log in using you Shotgun user account."
+                )
             
             data = app.shotgun.find_one("Task", [["id", "is", sg_data["id"]]], ["task_assignees"] )
             assignees = data["task_assignees"] or []

--- a/python/app/dialog.py
+++ b/python/app/dialog.py
@@ -848,6 +848,13 @@ class AppDialog(QtGui.QWidget):
         if sg_user_data:
             sg_location = ShotgunLocation(sg_user_data["type"], sg_user_data["id"])
             self._navigate_to(sg_location)
+        else:
+            self._app.log_warning(
+                "Navigation to the current user is not supported when "
+                "the Shotgun user cannot be determined. This is often the "
+                "case when Toolkit has been authenticated using a script key "
+                "rather than with a user name and password."
+            )
         
     def _on_home_clicked(self):
         """
@@ -963,6 +970,16 @@ class AppDialog(QtGui.QWidget):
                     # basic validation
                     if not dialog.new_task_name:
                         self._app.log_error("Please name your task!")
+                        return
+
+                    if self._app.context.user is None:
+                        self._app.log_error(
+                            "Shotgun Toolkit does not know what Shotgun user you are. "
+                            "This can be due to the use of a script key for authentication "
+                            "rather than using a user name and password login. To create and "
+                            "assign a Task, you will need to log in using you Shotgun user "
+                            "account."
+                        )
                         return
 
                     # create new task and assign!

--- a/python/app/model_entity_listing.py
+++ b/python/app/model_entity_listing.py
@@ -100,9 +100,20 @@ class SgEntityListingModel(ShotgunModel):
             fields += additional_fields
             
         hierarchy = [sort_field]
+
+        # This is wrapped here to account for the situation where we can't
+        # query for the My Tasks tab if we don't have a Shotgun user. This
+        # is the case when a script key is used for auth and we can't 
+        # determine a Shotgun human user by other means.
+        try:
+            filters = self._get_filters()
+        except sgtk.TankError as exc:
+            self.data_refresh_fail.emit(exc.message)
+            return
+
         ShotgunModel._load_data(self, 
                                 self._sg_formatter.entity_type, 
-                                self._get_filters(), 
+                                filters, 
                                 hierarchy, 
                                 fields, 
                                 [{"field_name": sort_field, 

--- a/python/app/shotgun_formatter.py
+++ b/python/app/shotgun_formatter.py
@@ -665,7 +665,16 @@ class ShotgunTypeFormatter(object):
 
             elif self._entity_type == "Task":
                 # my tasks tab on project
-                link_filters.append(["task_assignees", "in", [self._app.context.user]])
+                current_user = self._app.context.user
+
+                if current_user is None:
+                    raise sgtk.TankError(
+                        "Use of the My Tasks tab is not supported when a current Shotgun user "
+                        "cannot be determined. This is most often the case when a script key "
+                        "is used for authentication rather than a user name and password."
+                    )
+
+                link_filters.append(["task_assignees", "in", [current_user]])
                 link_filters.append(["sg_status_list", "is_not", "fin"])
                 link_filters.append(["project", "is", sg_location.entity_dict])
 

--- a/python/app/shotgun_formatter.py
+++ b/python/app/shotgun_formatter.py
@@ -741,7 +741,13 @@ class ShotgunEntityFormatter(ShotgunTypeFormatter):
         """
         Returns true if the formatter represents the current user.
         """
-        if self.entity_type == self._app.context.user.get("type") and \
+        # Note: the context's user might be None if we're authenticated with a
+        # script key and the user's current OS login doesn't match their Shotgun
+        # user name. In that situation, we don't know what the Shotgun user is,
+        # and we get a None back from the context. In that case, we need to
+        # assume that is_current_user is False.
+        if self._app.context.user is not None and \
+            self.entity_type == self._app.context.user.get("type") and \
             self.entity_id == self._app.context.user.get("id"):
             return True
         else:


### PR DESCRIPTION
If script-key authentication is used and the current OS username doesn't match that user's Shotgun login, Toolkit doesn't know what Shotgun user to retrieve from Shotgun. A side effect of that is a None value for the current user in the context object, which resulted in an unhandled exception being raised when the panel attempted to use that None value as an entity dictionary.