### PR TITLE
[SHOT-3114] Shotgun Panel "Copy to clipboard" action doesn't work in VRED

### DIFF
--- a/hooks/general_actions.py
+++ b/hooks/general_actions.py
@@ -210,8 +210,7 @@ class GeneralActions(HookBaseClass):
         :param text: content to copy
         """
         from sgtk.platform.qt import QtCore, QtGui
-        app = QtCore.QCoreApplication.instance()
-        app.clipboard().setText(text)
+        QtGui.QApplication.clipboard().setText(text)
 
     def _format_timestamp(self, datetime_obj):
         """


### PR DESCRIPTION
As VRED uses PySide2, we need to replace the use of QtCoreApplication.clipboard() by QApplication.clipboard() as the previous method is no longer available in PySide2. Otherwise, the "Copy to clipboard" action doesn't work in VRED