### PR TITLE
SG-14164: Tweaks styling to avoid crashing Nuke 12.

### DIFF
--- a/style.qss
+++ b/style.qss
@@ -80,20 +80,11 @@ QTabBar::tab:selected {
     font-style: italic;
 }
 
-#button, #action_button {
+QPushButton#button, QPushButton#action_button {
     border: 1px solid rgba(50, 50, 50, 50%);
-    background-color: rgba(50, 50, 50, 15%);
+    background-color: rgba(200, 200, 200, 20%);
     border-radius: 2px;
 }
-
-QPushButton#action_button:hover {
-    background-color: rgba(200, 200, 200, 18%);
-}
-
-QPushButton#button:hover {
-    background-color: rgba(200, 200, 200, 18%);
-}
-
 
 /****************************************************************/
 /* Info tab showing all shotgun fields 							*/


### PR DESCRIPTION
Nuke 12 crashes when shotgunpanel styling is applied. This makes some very minor tweaks to the qss to prevent that. Note that I don't know 100% why the crash occurred, but these tweaks resolve it without making any noticeable change in styling for the app.