### PR TITLE
SHOT-2756: Fix panel dialog title when not docked

### DIFF
--- a/app.py
+++ b/app.py
@@ -232,7 +232,7 @@ class ShotgunPanelApp(Application):
         :returns: The widget associated with the dialog.
         """
         app_payload = self.import_module("app")
-        widget = self.engine.show_dialog("Shotgun", self, app_payload.AppDialog)
+        widget = self.engine.show_dialog("Panel", self, app_payload.AppDialog)
         self._current_dialog = widget
         return widget
 


### PR DESCRIPTION
* The Shotgun Panel title reads **"Shotgun: Shotgun"** when it is not docked -- change title to **"Shotgun: Panel"**
* The panel title when docked will remain the same, "Shotgun"
* The panel title is different when not docked since `tk-core` prepends "Shotgun: " to any undocked dialog title

This PR is to replace the PR made to tk-core:  https://github.com/shotgunsoftware/tk-core/pull/790