### PR TITLE
Fix the app close event to properly shut down

### DIFF
--- a/python/app/dialog.py
+++ b/python/app/dialog.py
@@ -244,7 +244,7 @@ class AppDialog(QtGui.QWidget):
         # register a shutdown overlay
         splash_pix = QtGui.QPixmap(":/tk_multi_infopanel/bye_for_now.png")
         self._overlay.show_message_pixmap(splash_pix)
-        QtCore.QCoreApplication.processEvents()
+        self._overlay.repaint()
 
         try:
 


### PR DESCRIPTION
* Replace call to QtCore.QCoreApplication.processEvent with a call to only repaint the widget to show close message
* The processEvents call was causing the whole DCC application to quit before the SG panel app had fully shut down, as well as any other apps that were not yet shut down would never have properly closed


To expand on this:

The call to `processEvents` will process pending events for the calling thread -- so what is happening when we call `processEvents` during the app `closeEvent`, it interrupts the closeEvent function to process other pending events and 
the other pending events actually close the app, which causes the closeEvent function to never finish.

The widget `repaint` method should be enough to redraw the overlay as desired, instead of calling processEvents.

On a more general note, we should be cautious to use the `processEvents` method, as per this reference: https://forum.qt.io/topic/75333/what-does-qapplication-processevents-do