### PR TITLE
SG-25623 tasks not showing on the shotgrid panel

### DIFF
--- a/python/app/dialog.py
+++ b/python/app/dialog.py
@@ -1028,9 +1028,9 @@ class AppDialog(QtGui.QWidget):
             self.setup_entity_model_view(data)
 
             # Add the widgets to the layout in this order:
-            # HBox: description (QLabel) - strech [- sort] [- filter]
+            # HBox: description (QLabel) - stretch [- sort] [- filter]
             # view (QListView)
-            # Hbox: [filter (QCheckbox)] [- strech - partial result (QLabel)]
+            # Hbox: [filter (QCheckbox)] [- stretch - partial result (QLabel)]
             if data["has_description"]:
                 label = self.create_entity_tab_label(entity_tab_name, tab_widget)
                 data["description"] = label

--- a/python/app/dialog.py
+++ b/python/app/dialog.py
@@ -1030,7 +1030,7 @@ class AppDialog(QtGui.QWidget):
             # Add the widgets to the layout in this order:
             # HBox: description (QLabel) - strech [- sort] [- filter]
             # view (QListView)
-            # [filter (QCheckbox)]
+            # Hbox: [filter (QCheckbox)] [- strech - partial result (QLabel)]
             if data["has_description"]:
                 label = self.create_entity_tab_label(entity_tab_name, tab_widget)
                 data["description"] = label
@@ -1073,10 +1073,23 @@ class AppDialog(QtGui.QWidget):
             if data.get("view"):
                 tab_widget.layout().addWidget(data.get("view"))
 
-            if data["has_filter"]:
-                tab_widget.layout().addWidget(checkbox)
-                data["filter_checkbox"] = checkbox
+            if data["has_view"] or data["has_filter"]:
+                layout = QtGui.QHBoxLayout()
 
+                if data["has_filter"]:
+                    layout.addWidget(checkbox)
+                    data["filter_checkbox"] = checkbox
+
+                if data["has_view"]:
+                    qlabel_partial = self.create_entity_tab_label(entity_tab_name, tab_widget)
+                    qlabel_partial.setVisible(False)
+
+                    layout.addStretch()
+                    layout.addWidget(qlabel_partial)
+                    data["model"].label_partial = qlabel_partial
+
+                tab_widget.layout().addLayout(layout)
+ 
             data["widget"] = tab_widget
 
             tab_data[entity_tab_name] = data

--- a/python/app/dialog.py
+++ b/python/app/dialog.py
@@ -1081,7 +1081,9 @@ class AppDialog(QtGui.QWidget):
                     data["filter_checkbox"] = checkbox
 
                 if data["has_view"]:
-                    qlabel_partial = self.create_entity_tab_label(entity_tab_name, tab_widget)
+                    qlabel_partial = self.create_entity_tab_label(
+                        entity_tab_name, tab_widget
+                    )
                     qlabel_partial.setVisible(False)
 
                     layout.addStretch()

--- a/python/app/dialog.py
+++ b/python/app/dialog.py
@@ -1027,8 +1027,10 @@ class AppDialog(QtGui.QWidget):
             # entity data passed in with the created model, view, delegate and other necessary objects
             self.setup_entity_model_view(data)
 
-            # Add the widgets to the layout in this order: description (QLabel),
-            # view (QListView), filter (QCheckbox)
+            # Add the widgets to the layout in this order:
+            # HBox: description (QLabel) - strech [- sort] [- filter]
+            # view (QListView)
+            # [filter (QCheckbox)]
             if data["has_description"]:
                 label = self.create_entity_tab_label(entity_tab_name, tab_widget)
                 data["description"] = label

--- a/python/app/dialog.py
+++ b/python/app/dialog.py
@@ -1089,7 +1089,7 @@ class AppDialog(QtGui.QWidget):
                     data["model"].label_partial = qlabel_partial
 
                 tab_widget.layout().addLayout(layout)
- 
+
             data["widget"] = tab_widget
 
             tab_data[entity_tab_name] = data

--- a/python/app/dialog.py
+++ b/python/app/dialog.py
@@ -1081,14 +1081,14 @@ class AppDialog(QtGui.QWidget):
                     data["filter_checkbox"] = checkbox
 
                 if data["has_view"]:
-                    qlabel_partial = self.create_entity_tab_label(
+                    label_nb_items_status = self.create_entity_tab_label(
                         entity_tab_name, tab_widget
                     )
-                    qlabel_partial.setVisible(False)
+                    label_nb_items_status.setVisible(False)
 
                     layout.addStretch()
-                    layout.addWidget(qlabel_partial)
-                    data["model"].label_partial = qlabel_partial
+                    layout.addWidget(label_nb_items_status)
+                    data["model"].label_nb_items_status = label_nb_items_status
 
                 tab_widget.layout().addLayout(layout)
 

--- a/python/app/model_entity_listing.py
+++ b/python/app/model_entity_listing.py
@@ -39,12 +39,12 @@ class SgEntityListingModel(ShotgunModel):
 
     TEXT_NUM_ITEMS_FULL = "Showing {num} {entity_type}s"
     TEXT_NUM_ITEMS_PARTIAL = "Only showing the first {num} {entity_type}s"
-    TEXT_NUM_ITEMS_TT_FULL = "This is the number of items loaded from ShotGrid."
-    TEXT_NUM_ITEMS_TT_PATIAL = (
-        "Results are limited. "
+    TEXT_NUM_ITEMS_TT_FULL = "This number of records is loaded from ShotGrid."
+    TEXT_NUM_ITEMS_TT_PARTIAL_FIRST = "Results are limited."
+    TEXT_NUM_ITEMS_TT_PARTIAL_MIDDLE = None
+    TEXT_NUM_ITEMS_TT_PARTIAL_LAST = (
         "To see a list of all results, visit your entity pages in ShotGrid."
     )
-    TEXT_NUM_ITEMS_TT_PARTIAL_EXTRA = None
 
     def __init__(self, entity_type, parent, bg_task_manager):
         """
@@ -230,13 +230,16 @@ class SgEntityListingModel(ShotgunModel):
 
         self.label_nb_items_status.setVisible(self.rowCount() > 0)
 
-        text = self.TEXT_NUM_ITEMS_FULL
-        tooltip = self.TEXT_NUM_ITEMS_TT_FULL
         if self.content_is_partial:
             text = self.TEXT_NUM_ITEMS_PARTIAL
-            tooltip = self.TEXT_NUM_ITEMS_TT_PATIAL
-            if self.TEXT_NUM_ITEMS_TT_PARTIAL_EXTRA:
-                tooltip += "\n\n" + self.TEXT_NUM_ITEMS_TT_PARTIAL_EXTRA
+            tooltip = self.TEXT_NUM_ITEMS_TT_PARTIAL_FIRST
+            if self.TEXT_NUM_ITEMS_TT_PARTIAL_MIDDLE:
+                tooltip += " " + self.TEXT_NUM_ITEMS_TT_PARTIAL_MIDDLE
+
+            tooltip += " " + self.TEXT_NUM_ITEMS_TT_PARTIAL_LAST
+        else:
+            text = self.TEXT_NUM_ITEMS_FULL
+            tooltip = self.TEXT_NUM_ITEMS_TT_FULL
 
         self.label_nb_items_status.setText(
             text.format(

--- a/python/app/model_entity_listing.py
+++ b/python/app/model_entity_listing.py
@@ -35,7 +35,7 @@ class SgEntityListingModel(ShotgunModel):
     """
 
     # maximum number of items to show in the listings
-    SG_RECORD_LIMIT = 50
+    SG_RECORD_LIMIT = 200
 
     def __init__(self, entity_type, parent, bg_task_manager):
         """

--- a/python/app/model_entity_listing.py
+++ b/python/app/model_entity_listing.py
@@ -37,11 +37,12 @@ class SgEntityListingModel(ShotgunModel):
     # maximum number of items to show in the listings
     SG_RECORD_LIMIT = 200
 
-    TEXT_NUM_ITEMS = "{num} items loaded"
-    TEXT_NUM_ITEMS_PARTIAL_SUFFIX = "(partial result)"
-    TEXT_NUM_ITEMS_TT = "This is the number of items loaded from ShotGrid."
+    TEXT_NUM_ITEMS_FULL = "Showing {num} {entity_type}s"
+    TEXT_NUM_ITEMS_PARTIAL = "Only showing the first {num} {entity_type}s"
+    TEXT_NUM_ITEMS_TT_FULL = "This is the number of items loaded from ShotGrid."
     TEXT_NUM_ITEMS_TT_PATIAL = (
-        "This panel only loads a maximum of {max_num} items from ShotGrid."
+        "Results are limited. "
+        "To see a list of all results, visit your entity pages in ShotGrid."
     )
     TEXT_NUM_ITEMS_TT_PARTIAL_EXTRA = None
 
@@ -229,10 +230,10 @@ class SgEntityListingModel(ShotgunModel):
 
         self.label_nb_items_status.setVisible(self.rowCount() > 0)
 
-        text = self.TEXT_NUM_ITEMS
-        tooltip = self.TEXT_NUM_ITEMS_TT
+        text = self.TEXT_NUM_ITEMS_FULL
+        tooltip = self.TEXT_NUM_ITEMS_TT_FULL
         if self.content_is_partial:
-            text += " " + self.TEXT_NUM_ITEMS_PARTIAL_SUFFIX
+            text = self.TEXT_NUM_ITEMS_PARTIAL
             tooltip = self.TEXT_NUM_ITEMS_TT_PATIAL
             if self.TEXT_NUM_ITEMS_TT_PARTIAL_EXTRA:
                 tooltip += "\n\n" + self.TEXT_NUM_ITEMS_TT_PARTIAL_EXTRA
@@ -241,6 +242,7 @@ class SgEntityListingModel(ShotgunModel):
             text.format(
                 num=self.rowCount(),
                 max_num=self.SG_RECORD_LIMIT,
+                entity_type=self._sg_formatter.entity_type.lower(),
             )
         )
 
@@ -248,5 +250,6 @@ class SgEntityListingModel(ShotgunModel):
             tooltip.format(
                 num=self.rowCount(),
                 max_num=self.SG_RECORD_LIMIT,
+                entity_type=self._sg_formatter.entity_type.lower(),
             )
         )

--- a/python/app/model_entity_listing.py
+++ b/python/app/model_entity_listing.py
@@ -56,12 +56,11 @@ class SgEntityListingModel(ShotgunModel):
             bg_task_manager=bg_task_manager,
         )
 
-        self.my_record_limit = self.SG_RECORD_LIMIT + 1 # partial result detection
+        self.my_record_limit = self.SG_RECORD_LIMIT + 1  # partial result detection
         self.content_is_partial = False
         self.label_partial = None
 
         self.data_refreshed.connect(self._on_data_updated)
-
 
     ############################################################################################
     # public interface
@@ -204,7 +203,7 @@ class SgEntityListingModel(ShotgunModel):
         processing takes place.
         """
 
-        self.content_is_partial = len(data)>= self.my_record_limit
+        self.content_is_partial = len(data) >= self.my_record_limit
         if self.content_is_partial:
             data = data[:-1]
 
@@ -223,18 +222,24 @@ class SgEntityListingModel(ShotgunModel):
         if not self.label_partial:
             return
 
-        self.label_partial.setVisible(self.rowCount()>0)
+        self.label_partial.setVisible(self.rowCount() > 0)
 
         text = "{num} items loaded"
         tooltip = "This is the number of items loaded from ShotGrid."
         if self.content_is_partial:
             text += " (partial result)"
-            tooltip = self._format_partial_tooltip("This panel only loads a maximum of {num} items from ShotGrid.")
+            tooltip = self._format_partial_tooltip(
+                "This panel only loads a maximum of {num} items from ShotGrid."
+            )
 
-        self.label_partial.setText(text.format(
-            num=self.rowCount(),
-        ))
+        self.label_partial.setText(
+            text.format(
+                num=self.rowCount(),
+            )
+        )
 
-        self.label_partial.setToolTip(tooltip.format(
-            num = self.SG_RECORD_LIMIT,
-        ))
+        self.label_partial.setToolTip(
+            tooltip.format(
+                num=self.SG_RECORD_LIMIT,
+            )
+        )

--- a/python/app/model_task_listing.py
+++ b/python/app/model_task_listing.py
@@ -156,10 +156,13 @@ class SgTaskListingModel(SgEntityListingModel):
     ############################################################################################
     # protected interface
     def _format_partial_tooltip(self, text):
-        return text + """
+        return (
+            text
+            + """
 
 Please use the "Sort" button to load items from ShotGrid in a different
 order and access hidden items here."""
+        )
 
 
 class TaskAssigneeModel(ShotgunModel):

--- a/python/app/model_task_listing.py
+++ b/python/app/model_task_listing.py
@@ -39,7 +39,7 @@ class SgTaskListingModel(SgEntityListingModel):
     request_user_thumbnails = QtCore.Signal(list)
 
     TEXT_NUM_ITEMS_TT_PARTIAL_EXTRA = (
-        'Please use the "Sort" button to load items from ShotGrid in a'
+        'Please use the "Sort" button to load tasks from ShotGrid in a'
         "different order and access hidden items here."
     )
 

--- a/python/app/model_task_listing.py
+++ b/python/app/model_task_listing.py
@@ -153,6 +153,14 @@ class SgTaskListingModel(SgEntityListingModel):
             icon = self._sg_formatter.create_thumbnail(image, sg_data)
             item.setIcon(QtGui.QIcon(icon))
 
+    ############################################################################################
+    # protected interface
+    def _format_partial_tooltip(self, text):
+        return text + """
+
+Please use the "Sort" button to load items from ShotGrid in a different
+order and access hidden items here."""
+
 
 class TaskAssigneeModel(ShotgunModel):
     """

--- a/python/app/model_task_listing.py
+++ b/python/app/model_task_listing.py
@@ -38,6 +38,11 @@ class SgTaskListingModel(SgEntityListingModel):
 
     request_user_thumbnails = QtCore.Signal(list)
 
+    TEXT_NUM_ITEMS_TT_PARTIAL_EXTRA = (
+        'Please use the "Sort" button to load items from ShotGrid in a'
+        "different order and access hidden items here."
+    )
+
     def __init__(self, entity_type, parent, bg_task_manager):
         """
         Constructor.
@@ -152,17 +157,6 @@ class SgTaskListingModel(SgEntityListingModel):
             sg_data = item.get_sg_data()
             icon = self._sg_formatter.create_thumbnail(image, sg_data)
             item.setIcon(QtGui.QIcon(icon))
-
-    ############################################################################################
-    # protected interface
-    def _format_partial_tooltip(self, text):
-        return (
-            text
-            + """
-
-Please use the "Sort" button to load items from ShotGrid in a different
-order and access hidden items here."""
-        )
 
 
 class TaskAssigneeModel(ShotgunModel):

--- a/python/app/model_task_listing.py
+++ b/python/app/model_task_listing.py
@@ -38,9 +38,8 @@ class SgTaskListingModel(SgEntityListingModel):
 
     request_user_thumbnails = QtCore.Signal(list)
 
-    TEXT_NUM_ITEMS_TT_PARTIAL_EXTRA = (
-        'Please use the "Sort" button to load tasks from ShotGrid in a'
-        "different order and access hidden items here."
+    TEXT_NUM_ITEMS_TT_PARTIAL_MIDDLE = (
+        "Use the Sort option to see results presented in a different order."
     )
 
     def __init__(self, entity_type, parent, bg_task_manager):


### PR DESCRIPTION
The panel used to load only 50 items from the SG API without any message to the user regarding "partial load".
It now loads 200 items and the number of items loaded is displayed in the tab's status bar alongside information about partial load if applicable.



Here is the change
![image](https://user-images.githubusercontent.com/16244608/203160068-77c75361-ca5c-4e4c-ae88-aea2f1fd471a.png)
