### PR TITLE
SG-34346 Fix Dialog widget saved in self._current_panel instead self._current_dialog

### DIFF
--- a/app.py
+++ b/app.py
@@ -221,7 +221,10 @@ class ShotgunPanelApp(Application):
             )
             widget = self.create_dialog()
         else:
-            self._current_panel = widget
+            if widget.objectName() == "Dialog":
+                self._current_dialog = widget
+            else:
+                self._current_panel = widget
 
         return widget
 


### PR DESCRIPTION
[Under Hiero, the `NukeEngine.show_panel` function will return `NukeEngine.show_dialog`](https://github.com/shotgunsoftware/tk-nuke/blob/3802c04d2dda0e76c60b1bf984a7a72570268be7/engine.py#L745C32-L745C32)
But the application will still store the created widget in `self._current_panel`, leaving `self._current_dialog` empty while a dialog is currently open, which may cause a possible creation of a second dialog.

This commit is fixing it. 