### PR TITLE
SG-17742 Attempt to fix the crash issue with Houdini

### DIFF
--- a/python/app/widget_all_fields.py
+++ b/python/app/widget_all_fields.py
@@ -85,7 +85,7 @@ class AllFieldsWidget(QtGui.QWidget):
                 # set it's parent to None so that it is removed from the widget hierarchy
                 x.setParent(None)
                 # mark it to be deleted when event processing returns to the main loop
-                x.deleteLater()
+                x.destroy()
 
             self._widgets = []
 


### PR DESCRIPTION
When opening the tk-multi-shotgunpanel in Houdini, the Houdini app crashes on exit. This has been [reported by the community](https://community.shotgridsoftware.com/t/houdini-sgtk-app-crash-on-close/8827/7).

This PR attempts to fix this by properly destroying Qt objects on close. This solution was inspired on tk-multi-workfiles2.

- Used `destroy` method from [tk-framework-shotgunutils](https://github.com/shotgunsoftware/tk-framework-shotgunutils/blob/master/python/shotgun_model/shotgun_query_model.py#L232) instead of Qt `deleteLater` which [causes issues](https://github.com/shotgunsoftware/tk-framework-shotgunutils/blob/master/python/utils/qt.py#L14-L17) with the garbage collector.
- Added util functions to debug object life cycle. Taken from [tk-multi-workfiles2](https://github.com/shotgunsoftware/tk-multi-workfiles2/blob/master/python/tk_multi_workfiles/util.py#L231C44-L231C44).
