### PR TITLE
SG-34789 Fixup blank home icon when FPTR user has no thumbnail defined

### DIFF
--- a/python/app/dialog.py
+++ b/python/app/dialog.py
@@ -211,6 +211,7 @@ class AppDialog(QtGui.QWidget):
         self._current_user_model.data_updated.connect(self._update_current_user)
         self._current_user_model.load()
         self.ui.current_user.clicked.connect(self._on_user_home_clicked)
+        self.user_icon_orig = self.ui.current_user.icon()
 
         # top detail section
         self._details_model = SgEntityDetailsModel(self, self._task_manager)
@@ -509,8 +510,12 @@ class AppDialog(QtGui.QWidget):
         """
         curr_user_pixmap = self._current_user_model.get_pixmap()
         if curr_user_pixmap:
-            # QToolbutton needs a QIcon
-            self.ui.current_user.setIcon(QtGui.QIcon(curr_user_pixmap))
+            icon = QtGui.QIcon(curr_user_pixmap)
+        else:
+            icon = self.user_icon_orig
+
+        # QToolbutton needs a QIcon
+        self.ui.current_user.setIcon(icon)
 
         # Update the reply icon
         sg_data = self._current_user_model.get_sg_data()

--- a/python/app/dialog.py
+++ b/python/app/dialog.py
@@ -150,6 +150,8 @@ class AppDialog(QtGui.QWidget):
         self.ui.refresh_button.setIcon(SGQIcon.refresh())
         self.ui.refresh_button.setToolTip("Click to refresh the current view.")
 
+        self.user_icon_orig = self.ui.current_user.icon()
+
         # create a note updater to run operations on notes in the db
         self._note_updater = NoteUpdater(self._task_manager, self)
 
@@ -211,7 +213,6 @@ class AppDialog(QtGui.QWidget):
         self._current_user_model.data_updated.connect(self._update_current_user)
         self._current_user_model.load()
         self.ui.current_user.clicked.connect(self._on_user_home_clicked)
-        self.user_icon_orig = self.ui.current_user.icon()
 
         # top detail section
         self._details_model = SgEntityDetailsModel(self, self._task_manager)

--- a/python/app/dialog.py
+++ b/python/app/dialog.py
@@ -508,9 +508,9 @@ class AppDialog(QtGui.QWidget):
         Update the current user icon
         """
         curr_user_pixmap = self._current_user_model.get_pixmap()
-
-        # QToolbutton needs a QIcon
-        self.ui.current_user.setIcon(QtGui.QIcon(curr_user_pixmap))
+        if curr_user_pixmap:
+            # QToolbutton needs a QIcon
+            self.ui.current_user.setIcon(QtGui.QIcon(curr_user_pixmap))
 
         # Update the reply icon
         sg_data = self._current_user_model.get_sg_data()


### PR DESCRIPTION
The icon was blank when the FPTR site would return a "none" thumbnail"

| Before      | After      |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/226e86e9-ad0f-4ee0-8076-770b540048c8) | ![image](https://github.com/user-attachments/assets/2a06df28-89e7-4206-8731-72f8d3f6c437) |


